### PR TITLE
Temporary fix for [BUG] incorrect stdout/stdin name #46

### DIFF
--- a/plugin/driver/eBPF/kern/include/utils.h
+++ b/plugin/driver/eBPF/kern/include/utils.h
@@ -211,7 +211,7 @@ static __always_inline void *get_path_str(struct path *path)
         if (d_sb != 0) {
             unsigned long s_magic = READ_KERN(d_sb->s_magic);
             if (s_magic == PIPEFS_MAGIC) {
-                //TODO: Get PIPE INODE NAME like pipe:[%lu], current use pipe[]
+                // TODO: Get PIPE INODE NAME like pipe:[%lu], currently use pipe:[]
                 char pipe_prefix[] = "pipe:[]";
                 bpf_probe_read_str(&(string_p->buf[0]), MAX_STRING_SIZE, (void *)pipe_prefix);
             }

--- a/plugin/driver/eBPF/kern/include/utils.h
+++ b/plugin/driver/eBPF/kern/include/utils.h
@@ -17,7 +17,7 @@
 #include "bpf_core_read.h"
 #include "bpf_endian.h"
 
-#ifdef CO-RE
+#ifdef CORE
 #define PIPEFS_MAGIC 0x50495045
 #endif
 

--- a/plugin/driver/eBPF/kern/include/utils.h
+++ b/plugin/driver/eBPF/kern/include/utils.h
@@ -17,6 +17,11 @@
 #include "bpf_core_read.h"
 #include "bpf_endian.h"
 
+#ifdef CO-RE
+#define PIPEFS_MAGIC 0x50495045
+#endif
+
+
 // TODO: 后期改成动态的
 /* R3 max value is outside of the array range */
 // 这个地方非常非常的坑，都因为 bpf_verifier 机制, 之前 buf_off > MAX_PERCPU_BUFSIZE - sizeof(int) 本身都是成立的


### PR DESCRIPTION
Temporary fix for [BUG] incorrect stdout/stdin name #46
To get PIPE inode name like pipe:[%lu], we need implement raw itoa for eBPF.